### PR TITLE
Rechtesteuerung Poi-Editor

### DIFF
--- a/src/main/java/de/cismet/cids/custom/objecteditors/wunda_blau/KlimastoppZwischenstoppEditor.java
+++ b/src/main/java/de/cismet/cids/custom/objecteditors/wunda_blau/KlimastoppZwischenstoppEditor.java
@@ -529,7 +529,13 @@ public class KlimastoppZwischenstoppEditor extends DefaultCustomObjectEditor imp
                 getConnectionContext());
             setMapWindow();
             bindingGroup.bind();
-            getCidsBean().setProperty(FIELD__TOPUBLISH, false);
+            if (getCidsBean().getMetaObject().getStatus() == MetaObject.NEW) {
+                try {
+                    getCidsBean().setProperty(FIELD__TOPUBLISH, false);
+                } catch (Exception e) {
+                    LOG.error("Cannot set default values", e);
+                }
+            }
             setTitle(getTitle());
         } catch (Exception ex) {
             LOG.error("Bean not set", ex);

--- a/src/main/java/de/cismet/cids/custom/objecteditors/wunda_blau/Poi_locationinstanceEditor.form
+++ b/src/main/java/de/cismet/cids/custom/objecteditors/wunda_blau/Poi_locationinstanceEditor.form
@@ -452,6 +452,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtFax">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.fax}" target="txtFax" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -466,6 +469,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtStrasse">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.strasse}" target="txtStrasse" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -480,6 +486,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtStadt">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.stadt}" target="txtStadt" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -494,6 +503,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtPLZ">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.plz}" target="txtPLZ" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -508,6 +520,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtTelefon">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.telefon}" target="txtTelefon" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -522,6 +537,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtEmail">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.email}" target="txtEmail" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -556,6 +574,7 @@
                     <Property name="lineWrap" type="boolean" value="true"/>
                     <Property name="rows" type="int" value="4"/>
                     <Property name="wrapStyleWord" type="boolean" value="true"/>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <BindingProperties>
                     <BindingProperty name="text" source="Form" sourcePath="${cidsBean.info}" target="txtaInfo" targetPath="text" updateStrategy="0" immediately="false">
@@ -568,6 +587,9 @@
               </SubComponents>
             </Container>
             <Component class="javax.swing.JTextField" name="txtUrl">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.url}" target="txtUrl" targetPath="text" updateStrategy="0" immediately="false"/>
               </BindingProperties>
@@ -591,6 +613,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtBezeichnung">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.geographicidentifier}" target="txtBezeichnung" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -647,6 +672,8 @@
                 <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                   <StringArray count="0"/>
                 </Property>
+                <Property name="enabled" type="boolean" value="false"/>
+                <Property name="lightWeightPopupEnabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
                 <BindingProperty name="selectedItem" source="Form" sourcePath="${cidsBean.pos}" target="cbGeomPoint" targetPath="selectedItem" updateStrategy="0" immediately="false">
@@ -669,6 +696,7 @@
                 <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                   <StringArray count="0"/>
                 </Property>
+                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
                 <BindingProperty name="selectedItem" source="Form" sourcePath="${cidsBean.geom_area}" target="cbGeomArea" targetPath="selectedItem" updateStrategy="0" immediately="false">
@@ -701,6 +729,7 @@
             </Component>
             <Component class="de.cismet.cids.editors.DefaultBindableReferenceCombo" name="cbInfoArt">
               <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
                 <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
                   <Dimension value="[200, 20]"/>
                 </Property>
@@ -737,6 +766,7 @@
                 <Property name="toolTipText" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
                   <ResourceString bundle="de/cismet/cids/custom/objecteditors/wunda_blau/Bundle.properties" key="PoiLocationsinstanceEditor.btnCreateAreaFromPoinr.toolTipText" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
                 </Property>
+                <Property name="enabled" type="boolean" value="false"/>
                 <Property name="focusPainted" type="boolean" value="false"/>
               </Properties>
               <Events>
@@ -766,6 +796,7 @@
                 <Property name="formatterFactory" type="javax.swing.JFormattedTextField$AbstractFormatterFactory" editor="org.netbeans.modules.form.editors.AbstractFormatterFactoryEditor" preCode="try {" postCode="} catch (java.text.ParseException ex) {&#xa;ex.printStackTrace();&#xa;}">
                   <Format format="****" subtype="-1" type="5"/>
                 </Property>
+                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
                 <BindingProperty name="value" source="Form" sourcePath="${cidsBean.wup_live_id}" target="jFormattedTextField1" targetPath="value" updateStrategy="0" immediately="false">
@@ -829,6 +860,7 @@
                   <Properties>
                     <Property name="columns" type="int" value="20"/>
                     <Property name="rows" type="int" value="1"/>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <BindingProperties>
                     <BindingProperty name="text" source="Form" sourcePath="${cidsBean.foto}" target="txtaImageUrl" targetPath="text" updateStrategy="0" immediately="false"/>
@@ -869,6 +901,7 @@
                   <Properties>
                     <Property name="columns" type="int" value="20"/>
                     <Property name="rows" type="int" value="1"/>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <BindingProperties>
                     <BindingProperty name="text" source="Form" sourcePath="${cidsBean.fotostrecke}" target="txtaWebsiteUrl" targetPath="text" updateStrategy="0" immediately="false"/>
@@ -890,6 +923,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtAuthor">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.urheber_foto}" target="txtAuthor" targetPath="text" updateStrategy="0" immediately="false"/>
               </BindingProperties>
@@ -947,6 +983,7 @@
                 <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                   <StringArray count="0"/>
                 </Property>
+                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
                 <BindingProperty name="selectedItem" source="Form" sourcePath="${cidsBean.fk_copyright}" target="cbCopy" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
@@ -1022,6 +1059,7 @@
                       <StringArray count="0"/>
                     </Property>
                     <Property name="selectionMode" type="int" value="0"/>
+                    <Property name="enabled" type="boolean" value="false"/>
                     <Property name="visibleRowCount" type="int" value="6"/>
                   </Properties>
                   <BindingProperties>
@@ -1047,6 +1085,7 @@
                     <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
                       <Image iconType="3" name="/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"/>
                     </Property>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnAddThemaActionPerformed"/>
@@ -1062,6 +1101,7 @@
                     <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
                       <Image iconType="3" name="/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"/>
                     </Property>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRemoveThemaActionPerformed"/>
@@ -1105,6 +1145,7 @@
                       <StringArray count="0"/>
                     </Property>
                     <Property name="selectionMode" type="int" value="0"/>
+                    <Property name="enabled" type="boolean" value="false"/>
                     <Property name="visibleRowCount" type="int" value="6"/>
                   </Properties>
                   <BindingProperties>
@@ -1130,6 +1171,7 @@
                     <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
                       <Image iconType="3" name="/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"/>
                     </Property>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnAddVeranstaltungsartActionPerformed"/>
@@ -1145,6 +1187,7 @@
                     <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
                       <Image iconType="3" name="/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"/>
                     </Property>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRemoveVeranstaltungsartActionPerformed"/>
@@ -1172,6 +1215,7 @@
             </Component>
             <Component class="de.cismet.cids.editors.DefaultBindableReferenceCombo" name="cbMainLocationType">
               <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
                 <Property name="maximumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
                   <Dimension value="[200, 20]"/>
                 </Property>
@@ -1242,6 +1286,7 @@
                     <Property name="model" type="javax.swing.ListModel" editor="org.netbeans.modules.form.editors2.ListModelEditor">
                       <StringArray count="0"/>
                     </Property>
+                    <Property name="enabled" type="boolean" value="false"/>
                     <Property name="visibleRowCount" type="int" value="6"/>
                   </Properties>
                   <BindingProperties>
@@ -1267,6 +1312,7 @@
                     <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
                       <Image iconType="3" name="/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"/>
                     </Property>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnAddZusNamenActionPerformed"/>
@@ -1282,6 +1328,7 @@
                     <Property name="icon" type="javax.swing.Icon" editor="org.netbeans.modules.form.editors2.IconEditor">
                       <Image iconType="3" name="/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"/>
                     </Property>
+                    <Property name="enabled" type="boolean" value="false"/>
                   </Properties>
                   <Events>
                     <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnRemoveZusNamenActionPerformed"/>
@@ -1312,6 +1359,7 @@
                 <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                   <StringArray count="0"/>
                 </Property>
+                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
                 <BindingProperty name="selectedItem" source="Form" sourcePath="${cidsBean.signatur}" target="cbSignatur" targetPath="selectedItem" updateStrategy="0" immediately="false">
@@ -1348,6 +1396,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JFormattedTextField" name="txtFarbe">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="value" source="Form" sourcePath="${cidsBean.color}" target="txtFarbe" targetPath="value" updateStrategy="0" immediately="false"/>
               </BindingProperties>
@@ -1376,6 +1427,7 @@
             <Component class="javax.swing.JCheckBox" name="chkVeroeffentlicht">
               <Properties>
                 <Property name="contentAreaFilled" type="boolean" value="false"/>
+                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
                 <BindingProperty name="selected" source="Form" sourcePath="${cidsBean.to_publish}" target="chkVeroeffentlicht" targetPath="selected" updateStrategy="0" immediately="false">
@@ -1407,6 +1459,7 @@
                 <Property name="model" type="javax.swing.ComboBoxModel" editor="org.netbeans.modules.form.editors2.ComboBoxModelEditor">
                   <StringArray count="0"/>
                 </Property>
+                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
                 <BindingProperty name="selectedItem" source="Form" sourcePath="${cidsBean.fk_prio_rvr}" target="cbRvrPrio" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
@@ -1434,6 +1487,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JComboBox" name="cbRvrKat">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="selectedItem" source="Form" sourcePath="${cidsBean.fk_kategorie}" target="cbRvrKat" targetPath="selectedItem" updateStrategy="0" immediately="false"/>
               </BindingProperties>
@@ -1503,6 +1559,9 @@
               </Constraints>
             </Component>
             <Component class="javax.swing.JTextField" name="txtKeyUrl">
+              <Properties>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
               <BindingProperties>
                 <BindingProperty name="text" source="Form" sourcePath="${cidsBean.keyurl}" target="txtKeyUrl" targetPath="text" updateStrategy="0" immediately="false">
                   <BindingParameter name="javax.swing.binding.ParameterKeys.TEXT_CHANGE_STRATEGY" value="javax.swing.binding.TextChangeStrategy.ON_TYPE"/>
@@ -1536,16 +1595,44 @@
             <Component class="javax.swing.JCheckBox" name="chkKeyPublish">
               <Properties>
                 <Property name="contentAreaFilled" type="boolean" value="false"/>
+                <Property name="enabled" type="boolean" value="false"/>
               </Properties>
               <BindingProperties>
-                <BindingProperty name="selected" source="Form" sourcePath="${cidsBean.key_publish}" target="chkKeyPublish" targetPath="selected" updateStrategy="0" immediately="false">
+                <BindingProperty name="selected" source="Form" sourcePath="${cidsBean.key_publish}" target="chkKeyPublish" targetPath="selected" updateStrategy="0" immediately="false"/>
+              </BindingProperties>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                  <GridBagConstraints gridX="1" gridY="12" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="17" weightX="0.0" weightY="0.0"/>
+                </Constraint>
+              </Constraints>
+            </Component>
+            <Component class="javax.swing.JLabel" name="lblToKlima">
+              <Properties>
+                <Property name="font" type="java.awt.Font" editor="org.netbeans.beaninfo.editors.FontEditor">
+                  <Font name="Tahoma" size="11" style="1"/>
+                </Property>
+                <Property name="text" type="java.lang.String" value="Klimarouten relevant:"/>
+              </Properties>
+              <Constraints>
+                <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
+                  <GridBagConstraints gridX="0" gridY="13" gridWidth="1" gridHeight="1" fill="0" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="17" weightX="0.0" weightY="0.0"/>
+                </Constraint>
+              </Constraints>
+            </Component>
+            <Component class="javax.swing.JCheckBox" name="chkToKlima">
+              <Properties>
+                <Property name="contentAreaFilled" type="boolean" value="false"/>
+                <Property name="enabled" type="boolean" value="false"/>
+              </Properties>
+              <BindingProperties>
+                <BindingProperty name="selected" source="Form" sourcePath="${cidsBean.to_klima}" target="chkToKlima" targetPath="selected" updateStrategy="0" immediately="false">
                   <Property name="nullValue" type="boolean" value="false"/>
                   <Property name="incompletePathValue" type="boolean" value="false"/>
                 </BindingProperty>
               </BindingProperties>
               <Constraints>
                 <Constraint layoutClass="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout" value="org.netbeans.modules.form.compat2.layouts.DesignGridBagLayout$GridBagConstraintsDescription">
-                  <GridBagConstraints gridX="1" gridY="12" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="17" weightX="0.0" weightY="0.0"/>
+                  <GridBagConstraints gridX="1" gridY="13" gridWidth="1" gridHeight="1" fill="1" ipadX="0" ipadY="0" insetsTop="5" insetsLeft="5" insetsBottom="5" insetsRight="5" anchor="17" weightX="0.0" weightY="0.0"/>
                 </Constraint>
               </Constraints>
             </Component>

--- a/src/main/java/de/cismet/cids/custom/objecteditors/wunda_blau/Poi_locationinstanceEditor.java
+++ b/src/main/java/de/cismet/cids/custom/objecteditors/wunda_blau/Poi_locationinstanceEditor.java
@@ -40,9 +40,6 @@ import java.awt.HeadlessException;
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 
-import java.io.IOException;
-
-import java.net.HttpURLConnection;
 import java.net.URL;
 
 import java.util.ArrayList;
@@ -110,11 +107,14 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
     PropertyChangeListener {
 
     //~ Static fields/initializers ---------------------------------------------
-
+    public static final String CONF_POI = "onlyPoi";
+    public static final String CONF_KLIMA = "poiToKlima";
+    
     public static final String FIELD__KEYURL = "keyurl";           // poi_locationinstance
     public static final String FIELD__WARTUNG = "wartung";         // poi_locationinstance
     public static final String FIELD__PUBLISH = "to_publish";      // poi_locationinstance
     public static final String FIELD__KEY_PUBLISH = "key_publish"; // poi_locationinstance
+    public static final String FIELD__TO_KLIMA = "to_klima";        // poi_locationinstance
     public static final String FIELD__ID = "id";                   // poi_locationinstance
     public static final String BUNDLE_NOKEYURL = "PoiLocationsinstanceEditor.isOkForSaving().noKeyUrl";
     public static final String BUNDLE_KEYURLFALSE = "PoiLocationsinstanceEditor.isOkForSaving().KeyUrlFalse";
@@ -176,6 +176,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
     private javax.swing.JComboBox cbTypes;
     private javax.swing.JComboBox cbVeranstaltungsarten;
     private javax.swing.JCheckBox chkKeyPublish;
+    private javax.swing.JCheckBox chkToKlima;
     private javax.swing.JCheckBox chkVeroeffentlicht;
     private javax.swing.JCheckBox chkWartung;
     private javax.swing.JDialog dlgAddLocationType;
@@ -214,6 +215,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
     private javax.swing.JLabel lblStadt;
     private javax.swing.JLabel lblStrasse;
     private javax.swing.JLabel lblTelefon;
+    private javax.swing.JLabel lblToKlima;
     private javax.swing.JLabel lblUrl;
     private javax.swing.JLabel lblUrl1;
     private javax.swing.JLabel lblUrlCheckImage;
@@ -493,6 +495,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 getCidsBean().setProperty(FIELD__PUBLISH, false);
                 getCidsBean().setProperty(FIELD__WARTUNG, false);
                 getCidsBean().setProperty(FIELD__KEY_PUBLISH, false);
+                getCidsBean().setProperty(FIELD__TO_KLIMA, false);
             } catch (Exception e) {
                 LOG.error("Cannot set default values", e);
             }
@@ -501,6 +504,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         if (chkVeroeffentlicht.isSelected()) {
             chkWartung.setEnabled(true);
         }
+        allowEditing();
     }
 
     /**
@@ -517,11 +521,11 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panAddLocationType = new javax.swing.JPanel();
         lblAuswaehlen = new javax.swing.JLabel();
         final MetaObject[] locationtypes = de.cismet.cids.custom.objectrenderer.utils.ObjectRendererUtils
-                    .getLightweightMetaObjectsForTable(
-                        "poi_locationtype",
-                        new String[] { "identification" },
-                        getConnectionContext());
-        if (locationtypes != null) {
+        .getLightweightMetaObjectsForTable(
+            "poi_locationtype",
+            new String[] { "identification" },
+            getConnectionContext());
+        if(locationtypes != null) {
             Arrays.sort(locationtypes);
             cbTypes = new javax.swing.JComboBox(locationtypes);
             panMenButtons = new javax.swing.JPanel();
@@ -538,11 +542,11 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
             panAddVeranstaltungsart = new javax.swing.JPanel();
             lblAuswaehlen1 = new javax.swing.JLabel();
             final MetaObject[] veranstaltungsarten = de.cismet.cids.custom.objectrenderer.utils.ObjectRendererUtils
-                        .getLightweightMetaObjectsForTable(
-                            "poi_veranstaltungsarten",
-                            new String[] { "name" },
-                            getConnectionContext());
-            if (veranstaltungsarten != null) {
+            .getLightweightMetaObjectsForTable(
+                "poi_veranstaltungsarten",
+                new String[] { "name" },
+                getConnectionContext());
+            if(veranstaltungsarten != null) {
                 Arrays.sort(veranstaltungsarten);
                 cbVeranstaltungsarten = new javax.swing.JComboBox(veranstaltungsarten);
                 panVeranstaltungsartButtons = new javax.swing.JPanel();
@@ -576,7 +580,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 cbGeomPoint = new DefaultCismapGeometryComboBoxEditor();
                 cbGeomArea = new DefaultCismapGeometryComboBoxEditor();
                 lblGeomPoint1 = new javax.swing.JLabel();
-                cbInfoArt = new DefaultBindableReferenceCombo(true);
+                cbInfoArt = new DefaultBindableReferenceCombo(true) ;
                 btnCreateAreaFromPoint = new javax.swing.JButton();
                 lblUrl1 = new javax.swing.JLabel();
                 jFormattedTextField1 = new javax.swing.JFormattedTextField();
@@ -608,10 +612,8 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 btnAddVeranstaltungsart = new javax.swing.JButton();
                 btnRemoveVeranstaltungsart = new javax.swing.JButton();
                 lblMainLocationType = new javax.swing.JLabel();
-                cbMainLocationType = new DefaultBindableReferenceCombo(true);
-                filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 0),
-                        new java.awt.Dimension(0, 0),
-                        new java.awt.Dimension(32767, 32767));
+                cbMainLocationType = new DefaultBindableReferenceCombo(true) ;
+                filler1 = new javax.swing.Box.Filler(new java.awt.Dimension(0, 0), new java.awt.Dimension(0, 0), new java.awt.Dimension(32767, 32767));
                 lblLocationTypes1 = new javax.swing.JLabel();
                 scpZusNamen = new javax.swing.JScrollPane();
                 lstZusNamen = new javax.swing.JList();
@@ -619,7 +621,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 btnAddZusNamen = new javax.swing.JButton();
                 btnRemoveZusNamen = new javax.swing.JButton();
                 lblSignatur = new javax.swing.JLabel();
-                cbSignatur = new FastBindableReferenceCombo("%1$2s", new String[] { "definition", "filename" });
+                cbSignatur = new FastBindableReferenceCombo("%1$2s", new String[]{"definition", "filename"});
                 lblFarbe = new javax.swing.JLabel();
                 txtFarbe = new javax.swing.JFormattedTextField(new HexcolorFormatter());
                 lblVeroeffentlicht = new javax.swing.JLabel();
@@ -636,6 +638,8 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 txtKeyUrl = new javax.swing.JTextField();
                 lblKeyPublish = new javax.swing.JLabel();
                 chkKeyPublish = new javax.swing.JCheckBox();
+                lblToKlima = new javax.swing.JLabel();
+                chkToKlima = new javax.swing.JCheckBox();
 
                 dlgAddLocationType.setTitle("Thema zuweisen");
                 dlgAddLocationType.setModal(true);
@@ -649,6 +653,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 gridBagConstraints = new java.awt.GridBagConstraints();
                 gridBagConstraints.insets = new java.awt.Insets(10, 10, 10, 10);
                 panAddLocationType.add(lblAuswaehlen, gridBagConstraints);
+
             }
             cbTypes.setMaximumSize(new java.awt.Dimension(100, 20));
             cbTypes.setMinimumSize(new java.awt.Dimension(100, 20));
@@ -664,12 +669,10 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
             btnMenAbort.setText("Abbrechen");
             btnMenAbort.addActionListener(new java.awt.event.ActionListener() {
-
-                    @Override
-                    public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                        btnMenAbortActionPerformed(evt);
-                    }
-                });
+                public void actionPerformed(java.awt.event.ActionEvent evt) {
+                    btnMenAbortActionPerformed(evt);
+                }
+            });
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 1;
             gridBagConstraints.gridy = 0;
@@ -679,12 +682,10 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
             btnMenOk.setText("Ok");
             btnMenOk.addActionListener(new java.awt.event.ActionListener() {
-
-                    @Override
-                    public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                        btnMenOkActionPerformed(evt);
-                    }
-                });
+                public void actionPerformed(java.awt.event.ActionEvent evt) {
+                    btnMenOkActionPerformed(evt);
+                }
+            });
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = 0;
@@ -717,12 +718,10 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
             btnNamesMenAbort.setText("Abbrechen");
             btnNamesMenAbort.addActionListener(new java.awt.event.ActionListener() {
-
-                    @Override
-                    public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                        btnNamesMenAbortActionPerformed(evt);
-                    }
-                });
+                public void actionPerformed(java.awt.event.ActionEvent evt) {
+                    btnNamesMenAbortActionPerformed(evt);
+                }
+            });
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 1;
             gridBagConstraints.gridy = 0;
@@ -732,12 +731,10 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
             btnNamesMenOk.setText("Ok");
             btnNamesMenOk.addActionListener(new java.awt.event.ActionListener() {
-
-                    @Override
-                    public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                        btnNamesMenOkActionPerformed(evt);
-                    }
-                });
+                public void actionPerformed(java.awt.event.ActionEvent evt) {
+                    btnNamesMenOkActionPerformed(evt);
+                }
+            });
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.gridx = 0;
             gridBagConstraints.gridy = 0;
@@ -773,6 +770,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
             gridBagConstraints = new java.awt.GridBagConstraints();
             gridBagConstraints.insets = new java.awt.Insets(10, 10, 10, 10);
             panAddVeranstaltungsart.add(lblAuswaehlen1, gridBagConstraints);
+
         }
         cbVeranstaltungsarten.setMaximumSize(new java.awt.Dimension(100, 20));
         cbVeranstaltungsarten.setMinimumSize(new java.awt.Dimension(100, 20));
@@ -788,12 +786,10 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
         btnVeranstaltungsartAbort.setText("Abbrechen");
         btnVeranstaltungsartAbort.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnVeranstaltungsartAbortActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnVeranstaltungsartAbortActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 0;
@@ -803,12 +799,10 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
         btnVeranstaltungsartOk.setText("Ok");
         btnVeranstaltungsartOk.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnVeranstaltungsartOkActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnVeranstaltungsartOkActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 0;
@@ -914,12 +908,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(lblArt, gridBagConstraints);
 
-        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fax}"),
-                txtFax,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtFax.setEnabled(false);
+
+        org.jdesktop.beansbinding.Binding binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fax}"), txtFax, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -932,12 +923,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(txtFax, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.strasse}"),
-                txtStrasse,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtStrasse.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.strasse}"), txtStrasse, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -950,12 +938,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(txtStrasse, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.stadt}"),
-                txtStadt,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtStadt.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.stadt}"), txtStadt, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -968,12 +953,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(txtStadt, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.plz}"),
-                txtPLZ,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtPLZ.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.plz}"), txtPLZ, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -986,12 +968,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(txtPLZ, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.telefon}"),
-                txtTelefon,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtTelefon.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.telefon}"), txtTelefon, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -1004,12 +983,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(txtTelefon, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.email}"),
-                txtEmail,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtEmail.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.email}"), txtEmail, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -1027,13 +1003,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         txtaInfo.setLineWrap(true);
         txtaInfo.setRows(4);
         txtaInfo.setWrapStyleWord(true);
+        txtaInfo.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.info}"),
-                txtaInfo,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.info}"), txtaInfo, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -1048,12 +1020,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(scpTxtInfo, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.url}"),
-                txtUrl,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtUrl.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.url}"), txtUrl, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -1073,12 +1042,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(lblBezeichnung, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.geographicidentifier}"),
-                txtBezeichnung,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtBezeichnung.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.geographicidentifier}"), txtBezeichnung, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -1118,12 +1084,10 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(lblGeomPoint, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.pos}"),
-                cbGeomPoint,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        cbGeomPoint.setEnabled(false);
+        cbGeomPoint.setLightWeightPopupEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.pos}"), cbGeomPoint, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         binding.setConverter(((DefaultCismapGeometryComboBoxEditor)cbGeomPoint).getConverter());
         bindingGroup.addBinding(binding);
 
@@ -1137,12 +1101,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(cbGeomPoint, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.geom_area}"),
-                cbGeomArea,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        cbGeomArea.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.geom_area}"), cbGeomArea, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         binding.setConverter(((DefaultCismapGeometryComboBoxEditor)cbGeomArea).getConverter());
         bindingGroup.addBinding(binding);
 
@@ -1164,25 +1125,19 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(lblGeomPoint1, gridBagConstraints);
 
+        cbInfoArt.setEnabled(false);
         cbInfoArt.setMaximumSize(new java.awt.Dimension(200, 20));
         cbInfoArt.setMinimumSize(new java.awt.Dimension(150, 20));
         cbInfoArt.setPreferredSize(new java.awt.Dimension(150, 20));
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.info_art}"),
-                cbInfoArt,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.info_art}"), cbInfoArt, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
         cbInfoArt.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    cbInfoArtActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cbInfoArtActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 10;
@@ -1192,22 +1147,16 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(cbInfoArt, gridBagConstraints);
 
-        btnCreateAreaFromPoint.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/wizard.png"))); // NOI18N
-        btnCreateAreaFromPoint.setText(org.openide.util.NbBundle.getMessage(
-                Poi_locationinstanceEditor.class,
-                "VermessungRissEditor.btnCombineGeometries.text"));                                     // NOI18N
-        btnCreateAreaFromPoint.setToolTipText(org.openide.util.NbBundle.getMessage(
-                Poi_locationinstanceEditor.class,
-                "PoiLocationsinstanceEditor.btnCreateAreaFromPoinr.toolTipText"));                      // NOI18N
+        btnCreateAreaFromPoint.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/wizard.png"))); // NOI18N
+        btnCreateAreaFromPoint.setText(org.openide.util.NbBundle.getMessage(Poi_locationinstanceEditor.class, "VermessungRissEditor.btnCombineGeometries.text")); // NOI18N
+        btnCreateAreaFromPoint.setToolTipText(org.openide.util.NbBundle.getMessage(Poi_locationinstanceEditor.class, "PoiLocationsinstanceEditor.btnCreateAreaFromPoinr.toolTipText")); // NOI18N
+        btnCreateAreaFromPoint.setEnabled(false);
         btnCreateAreaFromPoint.setFocusPainted(false);
         btnCreateAreaFromPoint.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnCreateAreaFromPointActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnCreateAreaFromPointActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 13;
@@ -1224,18 +1173,13 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panContent.add(lblUrl1, gridBagConstraints);
 
         try {
-            jFormattedTextField1.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(
-                    new javax.swing.text.MaskFormatter("****")));
+            jFormattedTextField1.setFormatterFactory(new javax.swing.text.DefaultFormatterFactory(new javax.swing.text.MaskFormatter("****")));
         } catch (java.text.ParseException ex) {
             ex.printStackTrace();
         }
+        jFormattedTextField1.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.wup_live_id}"),
-                jFormattedTextField1,
-                org.jdesktop.beansbinding.BeanProperty.create("value"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.wup_live_id}"), jFormattedTextField1, org.jdesktop.beansbinding.BeanProperty.create("value"));
         binding.setSourceNullValue(null);
         binding.setSourceUnreadableValue(null);
         binding.setConverter(new WupLiveIdConverter());
@@ -1274,13 +1218,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
         txtaImageUrl.setColumns(20);
         txtaImageUrl.setRows(1);
+        txtaImageUrl.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.foto}"),
-                txtaImageUrl,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.foto}"), txtaImageUrl, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
         jScrollPane1.setViewportView(txtaImageUrl);
@@ -1307,13 +1247,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
 
         txtaWebsiteUrl.setColumns(20);
         txtaWebsiteUrl.setRows(1);
+        txtaWebsiteUrl.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fotostrecke}"),
-                txtaWebsiteUrl,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fotostrecke}"), txtaWebsiteUrl, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
         jScrollPane2.setViewportView(txtaWebsiteUrl);
@@ -1335,12 +1271,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(lblAuthor, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.urheber_foto}"),
-                txtAuthor,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtAuthor.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.urheber_foto}"), txtAuthor, org.jdesktop.beansbinding.BeanProperty.create("text"));
         bindingGroup.addBinding(binding);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -1350,15 +1283,12 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(txtAuthor, gridBagConstraints);
 
-        lblUrlCheckImage.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/status-busy.png"))); // NOI18N
+        lblUrlCheckImage.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/status-busy.png"))); // NOI18N
         lblUrlCheckImage.addMouseListener(new java.awt.event.MouseAdapter() {
-
-                @Override
-                public void mouseClicked(final java.awt.event.MouseEvent evt) {
-                    lblUrlCheckImageMouseClicked(evt);
-                }
-            });
+            public void mouseClicked(java.awt.event.MouseEvent evt) {
+                lblUrlCheckImageMouseClicked(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 17;
@@ -1366,15 +1296,12 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 0, 5, 5);
         panContent.add(lblUrlCheckImage, gridBagConstraints);
 
-        lblUrlCheckWebsite.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/status-busy.png"))); // NOI18N
+        lblUrlCheckWebsite.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/status-busy.png"))); // NOI18N
         lblUrlCheckWebsite.addMouseListener(new java.awt.event.MouseAdapter() {
-
-                @Override
-                public void mouseClicked(final java.awt.event.MouseEvent evt) {
-                    lblUrlCheckWebsiteMouseClicked(evt);
-                }
-            });
+            public void mouseClicked(java.awt.event.MouseEvent evt) {
+                lblUrlCheckWebsiteMouseClicked(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 2;
         gridBagConstraints.gridy = 18;
@@ -1391,12 +1318,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent.add(lblCopy, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fk_copyright}"),
-                cbCopy,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        cbCopy.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fk_copyright}"), cbCopy, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -1440,16 +1364,11 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panContent2.add(lblLocationTypes, gridBagConstraints);
 
         lstLocationTypes.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
+        lstLocationTypes.setEnabled(false);
         lstLocationTypes.setVisibleRowCount(6);
 
-        org.jdesktop.beansbinding.ELProperty eLProperty = org.jdesktop.beansbinding.ELProperty.create(
-                "${cidsBean.locationtypes}");
-        org.jdesktop.swingbinding.JListBinding jListBinding = org.jdesktop.swingbinding.SwingBindings
-                    .createJListBinding(
-                        org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                        this,
-                        eLProperty,
-                        lstLocationTypes);
+        org.jdesktop.beansbinding.ELProperty eLProperty = org.jdesktop.beansbinding.ELProperty.create("${cidsBean.locationtypes}");
+        org.jdesktop.swingbinding.JListBinding jListBinding = org.jdesktop.swingbinding.SwingBindings.createJListBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, eLProperty, lstLocationTypes);
         bindingGroup.addBinding(jListBinding);
 
         scpLstLocationTypes.setViewportView(lstLocationTypes);
@@ -1467,28 +1386,24 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panButtons.setOpaque(false);
         panButtons.setLayout(new java.awt.GridBagLayout());
 
-        btnAddThema.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"))); // NOI18N
+        btnAddThema.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"))); // NOI18N
+        btnAddThema.setEnabled(false);
         btnAddThema.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnAddThemaActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnAddThemaActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panButtons.add(btnAddThema, gridBagConstraints);
 
-        btnRemoveThema.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"))); // NOI18N
+        btnRemoveThema.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"))); // NOI18N
+        btnRemoveThema.setEnabled(false);
         btnRemoveThema.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnRemoveThemaActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnRemoveThemaActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
@@ -1512,14 +1427,11 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panContent2.add(lblVeranstaltungsarten, gridBagConstraints);
 
         lstVeranstaltungsarten.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
+        lstVeranstaltungsarten.setEnabled(false);
         lstVeranstaltungsarten.setVisibleRowCount(6);
 
         eLProperty = org.jdesktop.beansbinding.ELProperty.create("${cidsBean.arr_veranstaltungsarten}");
-        jListBinding = org.jdesktop.swingbinding.SwingBindings.createJListBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                eLProperty,
-                lstVeranstaltungsarten);
+        jListBinding = org.jdesktop.swingbinding.SwingBindings.createJListBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, eLProperty, lstVeranstaltungsarten);
         bindingGroup.addBinding(jListBinding);
 
         scpLstVeranstaltungsarten.setViewportView(lstVeranstaltungsarten);
@@ -1537,28 +1449,24 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panButtonsVeranstaltungsarten.setOpaque(false);
         panButtonsVeranstaltungsarten.setLayout(new java.awt.GridBagLayout());
 
-        btnAddVeranstaltungsart.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"))); // NOI18N
+        btnAddVeranstaltungsart.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"))); // NOI18N
+        btnAddVeranstaltungsart.setEnabled(false);
         btnAddVeranstaltungsart.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnAddVeranstaltungsartActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnAddVeranstaltungsartActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panButtonsVeranstaltungsarten.add(btnAddVeranstaltungsart, gridBagConstraints);
 
-        btnRemoveVeranstaltungsart.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"))); // NOI18N
+        btnRemoveVeranstaltungsart.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"))); // NOI18N
+        btnRemoveVeranstaltungsart.setEnabled(false);
         btnRemoveVeranstaltungsart.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnRemoveVeranstaltungsartActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnRemoveVeranstaltungsartActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
@@ -1581,25 +1489,19 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent2.add(lblMainLocationType, gridBagConstraints);
 
+        cbMainLocationType.setEnabled(false);
         cbMainLocationType.setMaximumSize(new java.awt.Dimension(200, 20));
         cbMainLocationType.setMinimumSize(new java.awt.Dimension(150, 20));
         cbMainLocationType.setPreferredSize(new java.awt.Dimension(150, 20));
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.mainlocationtype}"),
-                cbMainLocationType,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.mainlocationtype}"), cbMainLocationType, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
         cbMainLocationType.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    cbMainLocationTypeActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cbMainLocationTypeActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 1;
         gridBagConstraints.gridy = 4;
@@ -1622,14 +1524,11 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(7, 5, 5, 5);
         panContent2.add(lblLocationTypes1, gridBagConstraints);
 
+        lstZusNamen.setEnabled(false);
         lstZusNamen.setVisibleRowCount(6);
 
         eLProperty = org.jdesktop.beansbinding.ELProperty.create("${cidsBean.alternativegeographicidentifier}");
-        jListBinding = org.jdesktop.swingbinding.SwingBindings.createJListBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                eLProperty,
-                lstZusNamen);
+        jListBinding = org.jdesktop.swingbinding.SwingBindings.createJListBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, eLProperty, lstZusNamen);
         bindingGroup.addBinding(jListBinding);
 
         scpZusNamen.setViewportView(lstZusNamen);
@@ -1645,28 +1544,24 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panButtons1.setOpaque(false);
         panButtons1.setLayout(new java.awt.GridBagLayout());
 
-        btnAddZusNamen.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"))); // NOI18N
+        btnAddZusNamen.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_add_mini.png"))); // NOI18N
+        btnAddZusNamen.setEnabled(false);
         btnAddZusNamen.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnAddZusNamenActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnAddZusNamenActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panButtons1.add(btnAddZusNamen, gridBagConstraints);
 
-        btnRemoveZusNamen.setIcon(new javax.swing.ImageIcon(
-                getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"))); // NOI18N
+        btnRemoveZusNamen.setIcon(new javax.swing.ImageIcon(getClass().getResource("/de/cismet/cids/custom/objecteditors/wunda_blau/edit_remove_mini.png"))); // NOI18N
+        btnRemoveZusNamen.setEnabled(false);
         btnRemoveZusNamen.addActionListener(new java.awt.event.ActionListener() {
-
-                @Override
-                public void actionPerformed(final java.awt.event.ActionEvent evt) {
-                    btnRemoveZusNamenActionPerformed(evt);
-                }
-            });
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnRemoveZusNamenActionPerformed(evt);
+            }
+        });
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.gridx = 0;
         gridBagConstraints.gridy = 1;
@@ -1690,13 +1585,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panContent2.add(lblSignatur, gridBagConstraints);
 
         ((FastBindableReferenceCombo)cbSignatur).setSorted(true);
+        cbSignatur.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.signatur}"),
-                cbSignatur,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.signatur}"), cbSignatur, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         binding.setSourceNullValue("");
         binding.setSourceUnreadableValue("<Error>");
         bindingGroup.addBinding(binding);
@@ -1719,12 +1610,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent2.add(lblFarbe, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.color}"),
-                txtFarbe,
-                org.jdesktop.beansbinding.BeanProperty.create("value"));
+        txtFarbe.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.color}"), txtFarbe, org.jdesktop.beansbinding.BeanProperty.create("value"));
         bindingGroup.addBinding(binding);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -1745,13 +1633,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panContent2.add(lblVeroeffentlicht, gridBagConstraints);
 
         chkVeroeffentlicht.setContentAreaFilled(false);
+        chkVeroeffentlicht.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.to_publish}"),
-                chkVeroeffentlicht,
-                org.jdesktop.beansbinding.BeanProperty.create("selected"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.to_publish}"), chkVeroeffentlicht, org.jdesktop.beansbinding.BeanProperty.create("selected"));
         binding.setSourceNullValue(false);
         binding.setSourceUnreadableValue(false);
         bindingGroup.addBinding(binding);
@@ -1773,12 +1657,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent2.add(lblRvrPrio, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fk_prio_rvr}"),
-                cbRvrPrio,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        cbRvrPrio.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fk_prio_rvr}"), cbRvrPrio, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -1799,12 +1680,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent2.add(lblRvrKat, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fk_kategorie}"),
-                cbRvrKat,
-                org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
+        cbRvrKat.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.fk_kategorie}"), cbRvrKat, org.jdesktop.beansbinding.BeanProperty.create("selectedItem"));
         bindingGroup.addBinding(binding);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -1837,12 +1715,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         chkWartung.setContentAreaFilled(false);
         chkWartung.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.wartung}"),
-                chkWartung,
-                org.jdesktop.beansbinding.BeanProperty.create("selected"));
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.wartung}"), chkWartung, org.jdesktop.beansbinding.BeanProperty.create("selected"));
         binding.setSourceNullValue(false);
         binding.setSourceUnreadableValue(false);
         bindingGroup.addBinding(binding);
@@ -1864,12 +1737,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent2.add(lblKeyUrl, gridBagConstraints);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.keyurl}"),
-                txtKeyUrl,
-                org.jdesktop.beansbinding.BeanProperty.create("text"));
+        txtKeyUrl.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.keyurl}"), txtKeyUrl, org.jdesktop.beansbinding.BeanProperty.create("text"));
         binding.setSourceNullValue(null);
         binding.setSourceUnreadableValue(null);
         bindingGroup.addBinding(binding);
@@ -1892,15 +1762,9 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         panContent2.add(lblKeyPublish, gridBagConstraints);
 
         chkKeyPublish.setContentAreaFilled(false);
+        chkKeyPublish.setEnabled(false);
 
-        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(
-                org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE,
-                this,
-                org.jdesktop.beansbinding.ELProperty.create("${cidsBean.key_publish}"),
-                chkKeyPublish,
-                org.jdesktop.beansbinding.BeanProperty.create("selected"));
-        binding.setSourceNullValue(false);
-        binding.setSourceUnreadableValue(false);
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.key_publish}"), chkKeyPublish, org.jdesktop.beansbinding.BeanProperty.create("selected"));
         bindingGroup.addBinding(binding);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
@@ -1910,6 +1774,31 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
         gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
         panContent2.add(chkKeyPublish, gridBagConstraints);
+
+        lblToKlima.setFont(new java.awt.Font("Tahoma", 1, 11)); // NOI18N
+        lblToKlima.setText("Klimarouten relevant:");
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 0;
+        gridBagConstraints.gridy = 13;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
+        panContent2.add(lblToKlima, gridBagConstraints);
+
+        chkToKlima.setContentAreaFilled(false);
+        chkToKlima.setEnabled(false);
+
+        binding = org.jdesktop.beansbinding.Bindings.createAutoBinding(org.jdesktop.beansbinding.AutoBinding.UpdateStrategy.READ_WRITE, this, org.jdesktop.beansbinding.ELProperty.create("${cidsBean.to_klima}"), chkToKlima, org.jdesktop.beansbinding.BeanProperty.create("selected"));
+        binding.setSourceNullValue(false);
+        binding.setSourceUnreadableValue(false);
+        bindingGroup.addBinding(binding);
+
+        gridBagConstraints = new java.awt.GridBagConstraints();
+        gridBagConstraints.gridx = 1;
+        gridBagConstraints.gridy = 13;
+        gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
+        gridBagConstraints.anchor = java.awt.GridBagConstraints.WEST;
+        gridBagConstraints.insets = new java.awt.Insets(5, 5, 5, 5);
+        panContent2.add(chkToKlima, gridBagConstraints);
 
         gridBagConstraints = new java.awt.GridBagConstraints();
         gridBagConstraints.fill = java.awt.GridBagConstraints.BOTH;
@@ -1925,7 +1814,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         add(panCenter, gridBagConstraints);
 
         bindingGroup.bind();
-    } // </editor-fold>//GEN-END:initComponents
+    }// </editor-fold>//GEN-END:initComponents
 
     /**
      * DOCUMENT ME!
@@ -2010,12 +1899,12 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnAddThemaActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnAddThemaActionPerformed
+    private void btnAddThemaActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnAddThemaActionPerformed
         StaticSwingTools.showDialog(StaticSwingTools.getParentFrame(Poi_locationinstanceEditor.this),
             dlgAddLocationType,
             true);
         refreshVeranstaltungsartenButtons();
-    }                                                                               //GEN-LAST:event_btnAddThemaActionPerformed
+    }//GEN-LAST:event_btnAddThemaActionPerformed
 
     /**
      * DOCUMENT ME!
@@ -2049,7 +1938,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnRemoveThemaActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnRemoveThemaActionPerformed
+    private void btnRemoveThemaActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRemoveThemaActionPerformed
         final Object selection = lstLocationTypes.getSelectedValue();
         if (selection != null) {
             final int answer = JOptionPane.showConfirmDialog(
@@ -2074,23 +1963,23 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
             }
         }
         refreshVeranstaltungsartenButtons();
-    }                                                                                  //GEN-LAST:event_btnRemoveThemaActionPerformed
+    }//GEN-LAST:event_btnRemoveThemaActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnMenAbortActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnMenAbortActionPerformed
+    private void btnMenAbortActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnMenAbortActionPerformed
         dlgAddLocationType.setVisible(false);
-    }                                                                               //GEN-LAST:event_btnMenAbortActionPerformed
+    }//GEN-LAST:event_btnMenAbortActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnMenOkActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnMenOkActionPerformed
+    private void btnMenOkActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnMenOkActionPerformed
         try {
             final Object selItem = cbTypes.getSelectedItem();
             if (selItem instanceof MetaObject) {
@@ -2101,25 +1990,25 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         } finally {
             dlgAddLocationType.setVisible(false);
         }
-    }                                                                            //GEN-LAST:event_btnMenOkActionPerformed
+    }//GEN-LAST:event_btnMenOkActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnAddZusNamenActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnAddZusNamenActionPerformed
+    private void btnAddZusNamenActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnAddZusNamenActionPerformed
         StaticSwingTools.showDialog(StaticSwingTools.getParentFrame(Poi_locationinstanceEditor.this),
             dlgAddZusNamen,
             true);
-    }                                                                                  //GEN-LAST:event_btnAddZusNamenActionPerformed
+    }//GEN-LAST:event_btnAddZusNamenActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnRemoveZusNamenActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnRemoveZusNamenActionPerformed
+    private void btnRemoveZusNamenActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRemoveZusNamenActionPerformed
         final Object selection = lstZusNamen.getSelectedValue();
         if (selection != null) {
             final int answer = JOptionPane.showConfirmDialog(
@@ -2143,24 +2032,24 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 }
             }
         }
-    }                                                                                     //GEN-LAST:event_btnRemoveZusNamenActionPerformed
+    }//GEN-LAST:event_btnRemoveZusNamenActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnNamesMenAbortActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnNamesMenAbortActionPerformed
+    private void btnNamesMenAbortActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnNamesMenAbortActionPerformed
         dlgAddZusNamen.setVisible(false);
         txtZusNamen.setText("");
-    }                                                                                    //GEN-LAST:event_btnNamesMenAbortActionPerformed
+    }//GEN-LAST:event_btnNamesMenAbortActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnNamesMenOkActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnNamesMenOkActionPerformed
+    private void btnNamesMenOkActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnNamesMenOkActionPerformed
         try {
             final String addName = txtZusNamen.getText();
             if (addName.length() > 0) {
@@ -2179,32 +2068,32 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
             txtZusNamen.setText("");
             dlgAddZusNamen.setVisible(false);
         }
-    }                                                                                 //GEN-LAST:event_btnNamesMenOkActionPerformed
+    }//GEN-LAST:event_btnNamesMenOkActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void cbInfoArtActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_cbInfoArtActionPerformed
+    private void cbInfoArtActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cbInfoArtActionPerformed
         // TODO add your handling code here:
-    } //GEN-LAST:event_cbInfoArtActionPerformed
+    }//GEN-LAST:event_cbInfoArtActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void cbMainLocationTypeActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_cbMainLocationTypeActionPerformed
+    private void cbMainLocationTypeActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cbMainLocationTypeActionPerformed
         // TODO add your handling code here:
-    } //GEN-LAST:event_cbMainLocationTypeActionPerformed
+    }//GEN-LAST:event_cbMainLocationTypeActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnCreateAreaFromPointActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnCreateAreaFromPointActionPerformed
+    private void btnCreateAreaFromPointActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnCreateAreaFromPointActionPerformed
         final CidsBean geom_pos = (CidsBean)cidsBean.getProperty("pos");
         final CidsBean geom_area = (CidsBean)cidsBean.getProperty("geom_area");
         if (geom_area != null) {
@@ -2236,14 +2125,14 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         } catch (Exception e) {
             LOG.fatal("Problem during setting the area geom", e);
         }
-    } //GEN-LAST:event_btnCreateAreaFromPointActionPerformed
+    }//GEN-LAST:event_btnCreateAreaFromPointActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void lblUrlCheckImageMouseClicked(final java.awt.event.MouseEvent evt) { //GEN-FIRST:event_lblUrlCheckImageMouseClicked
+    private void lblUrlCheckImageMouseClicked(final java.awt.event.MouseEvent evt) {//GEN-FIRST:event_lblUrlCheckImageMouseClicked
         final String foto = (String)cidsBean.getProperty("foto");
         if (foto != null) {
             try {
@@ -2257,14 +2146,14 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                     JOptionPane.ERROR_MESSAGE);
             }
         }
-    }                                                                                //GEN-LAST:event_lblUrlCheckImageMouseClicked
+    }//GEN-LAST:event_lblUrlCheckImageMouseClicked
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void lblUrlCheckWebsiteMouseClicked(final java.awt.event.MouseEvent evt) { //GEN-FIRST:event_lblUrlCheckWebsiteMouseClicked
+    private void lblUrlCheckWebsiteMouseClicked(final java.awt.event.MouseEvent evt) {//GEN-FIRST:event_lblUrlCheckWebsiteMouseClicked
         final String foto = (String)cidsBean.getProperty("fotostrecke");
         if (foto != null) {
             try {
@@ -2278,25 +2167,25 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                     JOptionPane.ERROR_MESSAGE);
             }
         }
-    }                                                                                  //GEN-LAST:event_lblUrlCheckWebsiteMouseClicked
+    }//GEN-LAST:event_lblUrlCheckWebsiteMouseClicked
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnAddVeranstaltungsartActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnAddVeranstaltungsartActionPerformed
+    private void btnAddVeranstaltungsartActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnAddVeranstaltungsartActionPerformed
         StaticSwingTools.showDialog(StaticSwingTools.getParentFrame(Poi_locationinstanceEditor.this),
             dlgAddVeranstaltungsart,
             true);
-    }                                                                                           //GEN-LAST:event_btnAddVeranstaltungsartActionPerformed
+    }//GEN-LAST:event_btnAddVeranstaltungsartActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnRemoveVeranstaltungsartActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnRemoveVeranstaltungsartActionPerformed
+    private void btnRemoveVeranstaltungsartActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnRemoveVeranstaltungsartActionPerformed
         final Object selection = lstVeranstaltungsarten.getSelectedValue();
         if (selection != null) {
             final int answer = JOptionPane.showConfirmDialog(
@@ -2320,23 +2209,23 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
                 }
             }
         }
-    }                                                                                              //GEN-LAST:event_btnRemoveVeranstaltungsartActionPerformed
+    }//GEN-LAST:event_btnRemoveVeranstaltungsartActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnVeranstaltungsartAbortActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnVeranstaltungsartAbortActionPerformed
+    private void btnVeranstaltungsartAbortActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnVeranstaltungsartAbortActionPerformed
         dlgAddVeranstaltungsart.setVisible(false);
-    }                                                                                             //GEN-LAST:event_btnVeranstaltungsartAbortActionPerformed
+    }//GEN-LAST:event_btnVeranstaltungsartAbortActionPerformed
 
     /**
      * DOCUMENT ME!
      *
      * @param  evt  DOCUMENT ME!
      */
-    private void btnVeranstaltungsartOkActionPerformed(final java.awt.event.ActionEvent evt) { //GEN-FIRST:event_btnVeranstaltungsartOkActionPerformed
+    private void btnVeranstaltungsartOkActionPerformed(final java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnVeranstaltungsartOkActionPerformed
         try {
             final Object selItem = cbVeranstaltungsarten.getSelectedItem();
             if (selItem instanceof MetaObject) {
@@ -2347,7 +2236,7 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         } finally {
             dlgAddVeranstaltungsart.setVisible(false);
         }
-    }                                                                                          //GEN-LAST:event_btnVeranstaltungsartOkActionPerformed
+    }//GEN-LAST:event_btnVeranstaltungsartOkActionPerformed
 
     /**
      * DOCUMENT ME!
@@ -2438,6 +2327,74 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         }
         return title;
     }
+    
+    private void allowEditing() {
+        try {
+            final String confAttrKlima = SessionManager.getConnection()
+                        .getConfigAttr(SessionManager.getSession().getUser(),
+                            CONF_KLIMA,
+                            getConnectionContext());
+            if (confAttrKlima != null && confAttrKlima.equals("true")) {
+                chkToKlima.setEnabled(true);
+            }
+        } catch (final ConnectionException ex) {
+            LOG.warn("error while getConfAttr: " + "poiToKlima", ex);
+        }
+        try {
+            final String confAttrPoi = SessionManager.getConnection()
+                        .getConfigAttr(SessionManager.getSession().getUser(),
+                            CONF_POI,
+                            getConnectionContext());
+            if (confAttrPoi != null && confAttrPoi.equals("true")) {
+                chkKeyPublish.setEnabled(true);
+                chkVeroeffentlicht.setEnabled(true);
+                txtAuthor.setEnabled(true);
+                txtBezeichnung.setEnabled(true);
+                txtEmail.setEnabled(true);
+                txtFarbe.setEnabled(true);
+                txtFax.setEnabled(true);
+                txtKeyUrl.setEnabled(true);
+                txtPLZ.setEnabled(true);
+                txtStadt.setEnabled(true);
+                txtStrasse.setEnabled(true);
+                txtTelefon.setEnabled(true);
+                txtUrl.setEnabled(true);
+                txtZusNamen.setEnabled(true);
+                txtaImageUrl.setEnabled(true);
+                txtaInfo.setEnabled(true);
+                txtaWebsiteUrl.setEnabled(true);
+                btnCreateAreaFromPoint.setEnabled(true);
+                jFormattedTextField1.setEnabled(true);
+                cbCopy.setEnabled(true);
+                cbGeomArea.setEnabled(true);
+                cbGeomPoint.setEnabled(true);
+                cbInfoArt.setEnabled(true);
+                cbMainLocationType.setEnabled(true);
+                cbRvrKat.setEnabled(true);
+                cbRvrPrio.setEnabled(true);
+                cbSignatur.setEnabled(true);
+                cbTypes.setEnabled(true);
+                cbVeranstaltungsarten.setEnabled(true);
+                lstLocationTypes.setEnabled(true);
+                lstVeranstaltungsarten.setEnabled(true);
+                lstZusNamen.setEnabled(true);
+                btnAddThema.setEnabled(true);
+                btnAddVeranstaltungsart.setEnabled(true);
+                btnAddZusNamen.setEnabled(true);
+                btnRemoveThema.setEnabled(true);
+                btnRemoveVeranstaltungsart.setEnabled(true);
+                btnRemoveZusNamen.setEnabled(true);
+                btnCreateAreaFromPoint.setEnabled(true);
+            } else {
+                chkWartung.setEnabled(false);
+                btnAddVeranstaltungsart.setEnabled(false);
+                btnRemoveVeranstaltungsart.setEnabled(false);
+            }
+        } catch (final ConnectionException ex) {
+            LOG.warn("error while getConfAttr: " + "onlyPoi", ex);
+        }
+    }
+
 
     /**
      * DOCUMENT ME!
@@ -2491,7 +2448,8 @@ public class Poi_locationinstanceEditor extends DefaultCustomObjectEditor implem
         }
         return "Point of Interest (POI)";
     }
-
+    
+    
     @Override
     public void propertyChange(final PropertyChangeEvent evt) {
         if (evt.getPropertyName().equals(FIELD__PUBLISH)) {


### PR DESCRIPTION
neues Attribut to_klima (für User mit Aktionsrechtattribut poiToKlima dürfen editieren)
die übrigen Attribute dürfen von Usern mit onlyPoi editiert werden

Attribut ist angelegt.
Konfigurationsattribute exemplarisch für SimmertS102 und HohmannB102 eingerichtet.


Kleine Änderung am Editor Klimastopp.